### PR TITLE
Fix Bing Ping URL

### DIFF
--- a/lib/middleman-sitemap-ping/extension.rb
+++ b/lib/middleman-sitemap-ping/extension.rb
@@ -4,8 +4,8 @@ module Middleman
   module SitemapPing
     class Extension < Middleman::Extension
       SERVICES = {
-        google: 'http://www.google.com/webmasters/tools/ping?sitemap=%SITEMAP_URL%',
-        bing:   'http://www.bing.com/ping?sitemap=%SITEMAP_URL%'
+        google: 'https://www.google.com/webmasters/tools/ping?sitemap=%SITEMAP_URL%',
+        bing:   'https://bing.com/webmaster/ping.aspx?sitemap=%SITEMAP_URL%'
       }
 
       SERVICES.each_key do |service|


### PR DESCRIPTION
The old URL is returning `410 Gone` since 2021-12-23.

```
Pinging http://www.google.com/webmasters/tools/ping?sitemap=https%3A%2F%2Fmanas.tech%2Fsitemap.xml
     success  SUCCESS!
Pinging http://www.bing.com/ping?sitemap=https%3A%2F%2Fmanas.tech%2Fsitemap.xml
OpenURI::HTTPError: 410 Gone
bundler: failed to load command: middleman (/home/runner/work/manas-website/manas-website/vendor/bundle/bin/middleman)
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:378:in `open_http'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:756:in `buffer_open'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:226:in `block in open_loop'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:224:in `catch'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:224:in `open_loop'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:165:in `open_uri'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:736:in `open'
  /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/2.6.0/open-uri.rb:35:in `open'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-sitemap-ping-1.0.0/lib/middleman-sitemap-ping/extension.rb:33:in `block in do_ping'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-sitemap-ping-1.0.0/lib/middleman-sitemap-ping/extension.rb:29:in `each'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-sitemap-ping-1.0.0/lib/middleman-sitemap-ping/extension.rb:29:in `do_ping'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-sitemap-ping-1.0.0/lib/middleman-sitemap-ping/extension.rb:20:in `after_build'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/extension.rb:479:in `block in bind_after_build'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/callback_manager.rb:57:in `instance_exec'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/callback_manager.rb:57:in `block in execute'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:1316:in `each'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:1316:in `traverse_depth_first'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/hamster-3.0.0/lib/hamster/vector.rb:431:in `each'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/callback_manager.rb:57:in `execute'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/callback_manager.rb:28:in `block in install_methods!'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/builder.rb:82:in `block in run!'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/util.rb:21:in `instrument'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/builder.rb:81:in `run!'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-cli-4.3.11/lib/middleman-cli/build.rb:84:in `block in build'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-core-4.3.11/lib/middleman-core/util.rb:21:in `instrument'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-cli-4.3.11/lib/middleman-cli/build.rb:83:in `build'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `block in invoke_all'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `each'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `map'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `invoke_all'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/group.rb:232:in `dispatch'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:116:in `invoke'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor.rb:40:in `block in register'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
  /home/runner/work/manas-website/manas-website/vendor/bundle/gems/middleman-cli-4.3.11/bin/middleman:70:in `<top (required)>'
  /home/runner/work/manas-website/manas-website/vendor/bundle/bin/middleman:23:in `load'
  /home/runner/work/manas-website/manas-website/vendor/bundle/bin/middleman:23:in `<top (required)>'
```

I haven't found any docs reflecting the change (the official docs [still show the bad URL](https://web.archive.org/web/20211216141640/https://www.bing.com/webmasters/help/Sitemaps-3b5cf6ed)), but this new URL works for us.